### PR TITLE
Support Python >= 3.5

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -6,10 +6,10 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
-    - name: set up python 3.8
+    - name: set up python 3.5
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.5'
     - name: install build requirements
       run: pip install setuptools wheel
     - name: install package requirements

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ sphinx:
   configuration: docs/source/conf.py
 
 python:
-  version: 3.8
+  version: 3.5
   install:
     - requirements: docs/requirements.txt
     - method: pip

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -8,7 +8,7 @@ Requirements
 ------------
 
 `clickhouse-pool` works with Windows and Unix based systems. The package
-requires Python 3.8 and above due to typing.
+requires Python 3.5 and above due to typing.
 
 Installation
 ------------

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setuptools.setup(
         "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.5",
     install_requires=[
         "clickhouse-driver"
     ],


### PR DESCRIPTION
Here's a proposal to support python versions >= 3.5. All tests passed for 3.5.7 and 3.6.2 on my side.

I'm not sure about the yml changes.