### PR TITLE
Release connection if client query returns an error

### DIFF
--- a/clickhouse_pool/pool.py
+++ b/clickhouse_pool/pool.py
@@ -169,5 +169,7 @@ class ChPool():
 
         """
         client = self.pull(key)
-        yield client
-        self.push(client=client)
+        try:
+            yield client
+        finally:
+            self.push(client=client)


### PR DESCRIPTION
Currently, after checking out a connection from pool and running a query
that errors (either due to a bug or e.g. clickhouse being inaccessible)
the connection is never reset. This can lead to the connection pool being filled with inaccessible connections.

Took a quick stab at fixing this - @ericmccarthy7 mind taking a look?